### PR TITLE
docs: improve README with PyPI install, usage examples, and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ UCP schemas. Import models from `ucp_sdk.models.schemas`:
 
 ```python
 from ucp_sdk.models.schemas.shopping.checkout import Checkout
-from ucp_sdk.models.schemas.shopping.types.line_item import LineItem
-from ucp_sdk.models.schemas.shopping.types.total import Total
 
 # Parse a UCP checkout response
 checkout = Checkout.model_validate(checkout_data)
@@ -84,15 +82,15 @@ All models support Pydantic validation and serialization:
 
 ```python
 from pydantic import ValidationError
+from ucp_sdk.models.schemas.shopping.checkout import Checkout
 
 # Validate data against UCP schemas
 try:
     checkout = Checkout.model_validate(data)
+    # Serialize to JSON-compatible dict
+    checkout_dict = checkout.model_dump(exclude_none=True)
 except ValidationError as e:
     print(e.errors())
-
-# Serialize to JSON-compatible dict
-checkout_dict = checkout.model_dump(exclude_none=True)
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uv add ucp-sdk
 
 ## Usage
 
-Import models from `ucp_sdk.models.schemas`:
+The example below parses a UCP checkout response and reads typed fields:
 
 ```python
 from ucp_sdk.models.schemas.shopping.checkout import Checkout

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Python.
 
 ## Installation
 
-Install from PyPI:
+To use this SDK in your own project, install it from PyPI:
 
 ```bash
 pip install ucp-sdk
 ```
 
-Or with [uv](https://docs.astral.sh/uv/):
+Or, if you are managing your project with [uv](https://docs.astral.sh/uv/):
 
 ```bash
 uv add ucp-sdk
@@ -51,8 +51,8 @@ uv add ucp-sdk
 
 ## Usage
 
-The SDK provides typed [Pydantic v2](https://docs.pydantic.dev/) models for all
-UCP schemas. Import models from `ucp_sdk.models.schemas`:
+The SDK provides typed Pydantic v2 models for all UCP schemas. Import models
+from `ucp_sdk.models.schemas`:
 
 ```python
 from ucp_sdk.models.schemas.shopping.checkout import Checkout
@@ -69,12 +69,12 @@ for item in checkout.line_items:
 
 ### Available model packages
 
-| Package | Description |
-|---------|-------------|
-| `ucp_sdk.models.schemas.shopping` | Checkout, cart, order, payment models |
-| `ucp_sdk.models.schemas.shopping.types` | Line items, totals, buyer, fulfillment, etc. |
-| `ucp_sdk.models.schemas.transports` | REST, MCP, and embedded protocol bindings |
-| `ucp_sdk.models.schemas` | Service definitions, capabilities, payment handlers |
+| Package                                 | Description                                         |
+| --------------------------------------- | --------------------------------------------------- |
+| `ucp_sdk.models.schemas.shopping`       | Checkout, cart, order, payment models               |
+| `ucp_sdk.models.schemas.shopping.types` | Line items, totals, buyer, fulfillment, etc.        |
+| `ucp_sdk.models.schemas.transports`     | REST, MCP, and embedded protocol bindings           |
+| `ucp_sdk.models.schemas`                | Service definitions, capabilities, payment handlers |
 
 ### Validation
 
@@ -86,7 +86,7 @@ from ucp_sdk.models.schemas.shopping.checkout import Checkout
 
 # Validate data against UCP schemas
 try:
-    checkout = Checkout.model_validate(data)
+    checkout = Checkout.model_validate(checkout_data)
     # Serialize to JSON-compatible dict
     checkout_dict = checkout.model_dump(exclude_none=True)
 except ValidationError as e:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ uv add ucp-sdk
 
 ## Usage
 
-The SDK provides typed Pydantic v2 models for all UCP schemas. Import models
-from `ucp_sdk.models.schemas`:
+Import models from `ucp_sdk.models.schemas`:
 
 ```python
 from ucp_sdk.models.schemas.shopping.checkout import Checkout

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@
   <b>Official Python library for the Universal Commerce Protocol (UCP).</b>
 </p>
 
+<p align="center">
+  <a href="https://pypi.org/project/ucp-sdk/"><img src="https://img.shields.io/pypi/v/ucp-sdk" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/ucp-sdk/"><img src="https://img.shields.io/pypi/pyversions/ucp-sdk" alt="Python versions"></a>
+  <a href="https://github.com/Universal-Commerce-Protocol/python-sdk/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Universal-Commerce-Protocol/python-sdk" alt="License"></a>
+</p>
+
 ## Overview
 
 This repository contains the Python SDK for the
@@ -31,24 +37,80 @@ Python.
 
 ## Installation
 
-For now, you can install the SDK using the following commands:
+Install from PyPI:
 
 ```bash
-# Clone the repository
-git clone https://github.com/Universal-Commerce-Protocol/python-sdk.git
+pip install ucp-sdk
+```
 
-# Navigate to the directory
-cd python-sdk
+Or with [uv](https://docs.astral.sh/uv/):
 
-# Install dependencies
-uv sync
+```bash
+uv add ucp-sdk
+```
+
+## Usage
+
+The SDK provides typed [Pydantic v2](https://docs.pydantic.dev/) models for all
+UCP schemas. Import models from `ucp_sdk.models.schemas`:
+
+```python
+from ucp_sdk.models.schemas.shopping.checkout import Checkout
+from ucp_sdk.models.schemas.shopping.types.line_item import LineItem
+from ucp_sdk.models.schemas.shopping.types.total import Total
+
+# Parse a UCP checkout response
+checkout = Checkout.model_validate(checkout_data)
+
+# Access typed fields
+print(checkout.status)       # "incomplete" | "ready_for_complete" | ...
+print(checkout.currency)     # ISO 4217 currency code
+for item in checkout.line_items:
+    print(f"{item.item.title}: {item.quantity}")
+```
+
+### Available model packages
+
+| Package | Description |
+|---------|-------------|
+| `ucp_sdk.models.schemas.shopping` | Checkout, cart, order, payment models |
+| `ucp_sdk.models.schemas.shopping.types` | Line items, totals, buyer, fulfillment, etc. |
+| `ucp_sdk.models.schemas.transports` | REST, MCP, and embedded protocol bindings |
+| `ucp_sdk.models.schemas` | Service definitions, capabilities, payment handlers |
+
+### Validation
+
+All models support Pydantic validation and serialization:
+
+```python
+from pydantic import ValidationError
+
+# Validate data against UCP schemas
+try:
+    checkout = Checkout.model_validate(data)
+except ValidationError as e:
+    print(e.errors())
+
+# Serialize to JSON-compatible dict
+checkout_dict = checkout.model_dump(exclude_none=True)
 ```
 
 ## Development
 
 ### Prerequisites
 
-This project uses `uv` for dependency management.
+This project uses [`uv`](https://docs.astral.sh/uv/) for dependency management.
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/Universal-Commerce-Protocol/python-sdk.git
+cd python-sdk
+
+# Install dependencies
+uv sync
+```
 
 ### Generating Pydantic Models
 


### PR DESCRIPTION
## Summary
- Replace clone-based installation with PyPI instructions (`pip install ucp-sdk` / `uv add ucp-sdk`)
- Add usage examples showing model imports, typed field access, and Pydantic validation
- Add model package reference table for discoverability
- Add PyPI version, Python versions, and license badges
- Move clone/setup instructions to Development section where they belong

Closes #1

## Test plan
- [ ] Badges render correctly on GitHub
- [ ] PyPI links resolve to https://pypi.org/project/ucp-sdk/
- [ ] Code examples match actual model field names (verified against generated models)
- [ ] All existing sections (Contributing, License, Generating Models) preserved unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)