### PR TITLE
fix: handle "optional" marker in ucp_request schema preprocessing

### DIFF
--- a/preprocess_schemas.py
+++ b/preprocess_schemas.py
@@ -306,12 +306,18 @@ def eval_prop_inclusion(name, data, op, base_required):
         include = False
     elif marker == "required":
         is_required = True
+    elif marker == "optional":
+        # A simple string "optional" marker overrides the base schema's required list for all operations.
+        is_required = False
     elif isinstance(marker, dict):
         val = marker.get(op)
         if val == "omit" or val is None:
             include = False
         elif val == "required":
             is_required = True
+        elif val == "optional":
+            # Override base schema's required list when a field is explicitly marked optional for a specific operation.
+            is_required = False
 
     return include, is_required
 

--- a/src/ucp_sdk/models/schemas/shopping/types/fulfillment_method_create_request.py
+++ b/src/ucp_sdk/models/schemas/shopping/types/fulfillment_method_create_request.py
@@ -40,7 +40,7 @@ class FulfillmentMethodCreateRequest(BaseModel):
     """
     Fulfillment method type.
     """
-    line_item_ids: list[str]
+    line_item_ids: list[str] | None = None
     """
     Line item IDs fulfilled via this method.
     """

--- a/src/ucp_sdk/models/schemas/shopping/types/line_item_update_request.py
+++ b/src/ucp_sdk/models/schemas/shopping/types/line_item_update_request.py
@@ -31,7 +31,7 @@ class LineItemUpdateRequest(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    id: str
+    id: str | None = None
     item: item_update_request.ItemUpdateRequest
     quantity: int = Field(..., ge=1)
     """

--- a/src/ucp_sdk/models/schemas/shopping/types/shipping_destination_create_request.py
+++ b/src/ucp_sdk/models/schemas/shopping/types/shipping_destination_create_request.py
@@ -31,7 +31,7 @@ class ShippingDestinationCreateRequest(PostalAddress):
     model_config = ConfigDict(
         extra="allow",
     )
-    id: str
+    id: str | None = None
     """
     ID specific to this shipping destination.
     """

--- a/src/ucp_sdk/models/schemas/shopping/types/shipping_destination_update_request.py
+++ b/src/ucp_sdk/models/schemas/shopping/types/shipping_destination_update_request.py
@@ -31,7 +31,7 @@ class ShippingDestinationUpdateRequest(PostalAddress):
     model_config = ConfigDict(
         extra="allow",
     )
-    id: str
+    id: str | None = None
     """
     ID specific to this shipping destination.
     """


### PR DESCRIPTION
# Description

Fix `eval_prop_inclusion` in `preprocess_schemas.py` to handle the `"optional"` value in `ucp_request` markers. Previously, fields marked as `"optional"` (in both string and per-operation dict forms) remained required in generated request models because the preprocessor only handled `"omit"` and `"required"` — the `"optional"` value fell through without overriding the base schema's `required` list.

This fix adds handling for `"optional"` in both code paths:
- **String form** (`"ucp_request": "optional"`) — applies to all operations (create and update)
- **Dict form** (`"ucp_request": {"create": "optional"}`) — applies per-operation

After the fix, `generate_models.sh` produces correct models where affected fields become `str | None = None` or `list[...] | None = None` instead of being required.

**Affected generated models:**
- `ShippingDestinationCreateRequest` / `ShippingDestinationUpdateRequest` — `id` now optional
- `FulfillmentMethodCreateRequest` — `line_item_ids` now optional
- `LineItemUpdateRequest` — affected field now optional

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Fixes #30
Fixes #31

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

<!-- If applicable, add screenshots or log output to help explain your changes. -->
