### PR TITLE
ci: verify committed models match regeneration from the pinned UCP spec

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package (generated-model tests import it)
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
       - name: Regenerate models from the pinned spec version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package (generated-model tests import it)
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
       - name: Regenerate models from the pinned spec version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,3 +42,39 @@ jobs:
         run: pip install -e .
       - name: Run preprocessing tests
         run: python -m unittest discover -s tests -p "test_*.py"
+
+  model-drift:
+    name: Generated models match the pinned UCP spec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - name: Regenerate models from the pinned spec version
+        # SDK 0.4.x targets UCP 2026-04-08 (see the README compatibility
+        # table). Bump this pin together with the SDK version line.
+        run: ./generate_models.sh 2026-04-08
+      - name: Normalize file endings (as pre-commit's end-of-file-fixer does)
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          for path in Path("src/ucp_sdk/models/schemas").rglob("*.py"):
+              text = path.read_text(encoding="utf-8")
+              fixed = text.rstrip("\n") + "\n" if text.strip() else ""
+              if fixed != text:
+                  path.write_text(fixed, encoding="utf-8")
+          PY
+      - name: Fail if regeneration does not reproduce the committed models
+        run: |
+          git add -A -- src/ucp_sdk/models/schemas
+          if ! git diff --cached --quiet -- src/ucp_sdk/models/schemas; then
+            echo "::error::Committed models differ from regeneration against the pinned UCP spec. Either the generation pipeline is broken, or the models were edited without regenerating. Run ./generate_models.sh 2026-04-08 and commit the result."
+            git --no-pager diff --cached --stat -- src/ucp_sdk/models/schemas
+            git --no-pager diff --cached -- src/ucp_sdk/models/schemas
+            exit 1
+          fi
+          echo "Committed models match regeneration."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,14 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "datamodel-code-generator[http,ruff]>=0.50.0",
+    # Exact pins: the model-drift CI job regenerates the models against the
+    # pinned UCP spec and asserts byte-identical output, so the codegen
+    # toolchain must resolve reproducibly. (The floating ">=0.50.0" bound
+    # broke on 2026-08-03: datamodel-code-generator 0.72.0 mis-resolves the
+    # spec's remote $refs and emits incomplete models.) Bump these pins and
+    # regenerate the models in the same PR.
+    "datamodel-code-generator[http]==0.71.0",
+    "ruff==0.16.1",
 ]
 
 [build-system]


### PR DESCRIPTION
## Observed

`tests.yml` installs the committed models and runs `unittest discover`; nothing in CI exercises the generation pipeline end to end. Three concrete consequences, all reproduced on current main:

1. The pipeline is broken today while CI is green: `./generate_models.sh 2026-04-08` fails on a clean checkout because the dev dependency bound is a floating `datamodel-code-generator>=0.50.0`, and 0.72.0 (released yesterday) mis resolves remote refs (`HTTP 404 .../shopping/shopping/shopping/types/product_option.json`), after which `postprocess_models.py` exits 1 (`'Description' has no generated class`). The exact CI steps still pass.
2. Gutting the `_patch_unique_items()` call in `postprocess_models.py` (committed models untouched) leaves CI green: `Ran 45 tests ... OK`.
3. If the package import fails, the behavioral model tests skip via `skipUnless(HAVE_SDK, ...)` and unittest reports `OK (skipped=15)`, exit 0.

The unit tests added with the recent validator work cover the postprocess functions in isolation and the committed models behaviorally; the wiring between the generator, the postprocessor and the committed artifacts is what has no coverage.

## Change

A `model-drift` CI job: regenerate against the pinned spec release the 0.4.x line targets (`./generate_models.sh 2026-04-08`, per the README compatibility table), normalize end of file (the only delta pre-commit introduces on generated output), and fail with an actionable message if the result differs from the committed models. Plus exact pins for the two generation-critical dev dependencies (`datamodel-code-generator==0.71.0`, `ruff==0.16.1`), with a comment documenting the 0.72.0 breakage; these versions reproduce the committed models byte for byte.

This deliberately does NOT regenerate at build time or auto commit anything (the committed artifact flow stays the release path, consistent with the direction in #10): it only asserts that what is committed and what the pipeline produces are the same thing, which catches both a broken generator and a forgotten regeneration.

## Verification

Green on clean HEAD (twice, including an end to end run of the exact job commands). Red in both failure directions: the gutted injector mutation (30 deleted validator lines detected) and a deliberately staled committed model (6 line diff detected). Full existing suite on the final tree: `Ran 45 tests ... OK`. One caveat stated up front: the `release/2026-04-08` branch has received cherry picks before (for example the attribution feature); if it moves again this job goes red on unrelated PRs, which is the intended signal that the committed models are stale relative to the pinned spec, and regenerating clears it.
