### PR TITLE
fix: handle transition-shaped ucp_request markers in eval_prop_inclusion

### DIFF
--- a/preprocess_schemas.py
+++ b/preprocess_schemas.py
@@ -412,6 +412,10 @@ def eval_prop_inclusion(name, data, op, base_required):
         is_required = False
     elif isinstance(marker, dict):
         val = marker.get(op)
+        if isinstance(val, dict):
+            # Handle transition-shaped marker: {"transition": {"from": "...", "to": "..."}}
+            transition = val.get("transition", {})
+            val = transition.get("to")
         if val == "omit" or val is None:
             include = False
         elif val == "required":

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -231,7 +231,9 @@ class RequestMetadataTest(unittest.TestCase):
                 "transition-omit",
                 {
                     "ucp_request": {
-                        "update": {"transition": {"from": "required", "to": "omit"}}
+                        "update": {
+                            "transition": {"from": "required", "to": "omit"}
+                        }
                     }
                 },
                 "update",

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -228,6 +228,17 @@ class RequestMetadataTest(unittest.TestCase):
                 (False, True),
             ),
             (
+                "transition-omit",
+                {
+                    "ucp_request": {
+                        "update": {"transition": {"from": "required", "to": "omit"}}
+                    }
+                },
+                "update",
+                ["field"],
+                (False, True),
+            ),
+            (
                 "undeclared-operation",
                 {"ucp_request": {"update": "required"}},
                 "create",


### PR DESCRIPTION
## Description

`eval_prop_inclusion` in `preprocess_schemas.py` did not handle the
`transition`-shaped `ucp_request` marker that UCP introduced for
`cart.json`'s `id` field:

```json
"ucp_request": {
  "update": {
    "transition": {
      "from": "required",
      "to": "omit"
    }
  }
}
```

When `marker.get(op)` returns a dict (the `{"transition": {...}}` form), the
existing branches only compare against the strings `"omit"` / `"required"` /
`"optional"`, none of which match a dict. The field therefore kept its base
default of `include=True` and `is_required = name in base_required`.

Result: the generated `CartUpdateRequest` marks `id: str` as required, but the
spec says `id` should be **omitted** in update requests (prefer transport-level
identification, no duplication). A field that a string `"omit"` marker handles
everywhere else is silently treated as required under the new transition form.

**Fix:** when the operation marker resolves to a dict, unwrap its
`transition.to` value before the existing `"omit"` / `"required"` /
`"optional"` checks, so transition markers behave like their plain-string
equivalents.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A — codegen pipeline fix, no schema/field removal.