### PR TITLE
fix: preserve conditional allOf branches

### DIFF
--- a/preprocess_schemas.py
+++ b/preprocess_schemas.py
@@ -104,6 +104,10 @@ def _process_all_of_item(item, node, root, state):
     if not isinstance(item, dict):
         return
 
+    if any(key in item for key in ("if", "then", "else")):
+        state["remaining_refs"].append(item)
+        return
+
     # Extract polymorphic branches (anyOf, oneOf) to keep the node flat
     for poly_key in ["anyOf", "oneOf"]:
         if poly_key in item:

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -91,6 +91,29 @@ class SchemaNormalizationTest(unittest.TestCase):
         self.assertEqual(set(branch["required"]), {"id", "kind"})
         self.assertEqual(branch["type"], "object")
 
+    def test_preprocess_preserves_multiple_conditional_branches(self) -> None:
+        """Each conditional allOf branch survives schema flattening."""
+        negative = {
+            "if": {"properties": {"type": {"const": "discount"}}},
+            "then": {"properties": {"amount": {"exclusiveMaximum": 0}}},
+        }
+        non_negative = {
+            "if": {"properties": {"type": {"const": "subtotal"}}},
+            "then": {"properties": {"amount": {"minimum": 0}}},
+        }
+        schema = {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string"},
+                "amount": {"type": "integer"},
+            },
+            "allOf": [negative, non_negative],
+        }
+
+        preprocess_schemas.preprocess_full_schema(schema)
+
+        self.assertEqual(schema["allOf"], [negative, non_negative])
+
     def test_preprocess_inlines_entity_fields(self) -> None:
         """The shared entity definition is inlined without its metadata."""
         entity = {


### PR DESCRIPTION
## Description

`merge_all_of_to_node` flattens each `allOf` branch into the parent schema. For
generic keys it keeps only the first occurrence:

```python
for k, v in item.items():
    if k not in reserved_keys and k not in node:
        node[k] = v
```

That loses conditional constraints when multiple branches each carry an
`if`/`then` pair. `shopping/types/total.json`, for example, has one branch that
requires discount amounts to be negative and another that requires positive
total types to be non-negative. After preprocessing, only the first `if` and
`then` survived.

**Fix:** keep conditional `allOf` branches intact instead of flattening their
`if`/`then`/`else` keys into the parent. A regression test supplies two distinct
conditional branches and verifies both remain after preprocessing.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

N/A

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- `python -m unittest discover -s tests -p 'test_*.py'` — 58 tests passed
- `pre-commit run --all-files` — passed
- `./generate_models.sh 2026-04-08` — completed; no generated model changes
