### PR TITLE
fix: allow equivalent metadata union members

### DIFF
--- a/preprocess_schemas.py
+++ b/preprocess_schemas.py
@@ -573,7 +573,7 @@ def normalize_metadata_schemas(schemas, target_dir):
     ucp_path = str((target_dir / "ucp.json").resolve())
     if ucp_path in schemas:
         ucp = schemas[ucp_path]
-        ucp["oneOf"] = [
+        ucp["anyOf"] = [
             {"$ref": f"#/$defs/{name}"} for name in metadata_union_members(ucp)
         ]
 

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -460,10 +460,10 @@ class VariantGenerationTest(unittest.TestCase):
 class PipelineDependencyTest(unittest.TestCase):
     """Tests metadata normalization and transitive variant dependencies."""
 
-    def test_normalize_metadata_schemas_sets_root_union_and_ucp_refs(
+    def test_normalize_metadata_schemas_sets_root_anyof_and_ucp_refs(
         self,
     ) -> None:
-        """Metadata schemas expose the root union and normalized references."""
+        """Equivalent response profiles remain valid metadata alternatives."""
         target_dir = Path("/schemas")
         ucp_path = str((target_dir / "ucp.json").resolve())
         checkout_path = str((target_dir / "checkout.json").resolve())
@@ -497,8 +497,9 @@ class PipelineDependencyTest(unittest.TestCase):
 
         preprocess_schemas.normalize_metadata_schemas(schemas, target_dir)
 
+        self.assertNotIn("oneOf", schemas[ucp_path])
         self.assertEqual(
-            schemas[ucp_path]["oneOf"],
+            schemas[ucp_path]["anyOf"],
             [
                 {"$ref": "#/$defs/platform_schema"},
                 {"$ref": "#/$defs/business_schema"},


### PR DESCRIPTION
## Description

`normalize_metadata_schemas()` synthesizes a root union for `ucp.json` using `oneOf`:

```python
ucp["oneOf"] = [
    {"$ref": f"#/$defs/{name}"} for name in metadata_union_members(ucp)
]
```

`response_cart_schema`, `response_catalog_schema`, and `response_order_schema` have the same validation shape; their differences are limited to annotations such as `title` and `description`. Any metadata instance matching one of these response profiles therefore matches all three, so the generated `oneOf` rejects it for matching more than one branch.

**Fix:** synthesize the metadata type union with `anyOf`. This preserves the existing member list while allowing equivalent response profiles, matching the generated Pydantic `Union` behavior.

## Category (Required)

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Fixes #73

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [x] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

- Draft 2020-12 reproduction: the synthesized `oneOf` returns one validation error for equivalent response members; `anyOf` returns zero.
- `uv run python -m unittest discover -s tests -p 'test_*.py'` — 77 passed.
- `./generate_models.sh 2026-04-08` — completed; no model behavior diff.
- `uvx pre-commit run --all-files` — passed.
- `git diff --check` — passed.
