### PR TITLE
fix: resolve entity local references before inlining (#72)

### DIFF
--- a/preprocess_schemas.py
+++ b/preprocess_schemas.py
@@ -86,6 +86,37 @@ def resolve_local_ref(ref, root):
     return current
 
 
+def resolve_local_refs(fragment, root, seen=None):
+    """
+    Recursively resolves and inlines local $ref pointers (#/...) within a schema fragment.
+    """
+    if seen is None:
+        seen = set()
+
+    if isinstance(fragment, dict):
+        if "$ref" in fragment:
+            ref = fragment["$ref"]
+            if (
+                isinstance(ref, str)
+                and ref.startswith("#/")
+                and ref not in seen
+            ):
+                target = resolve_local_ref(ref, root)
+                if target is not None:
+                    resolved = copy.deepcopy(target)
+                    resolve_local_refs(resolved, root, seen | {ref})
+                    for k, v in fragment.items():
+                        if k != "$ref":
+                            resolved[k] = v
+                    fragment.clear()
+                    fragment.update(resolved)
+        for v in list(fragment.values()):
+            resolve_local_refs(v, root, seen)
+    elif isinstance(fragment, list):
+        for item in fragment:
+            resolve_local_refs(item, root, seen)
+
+
 # --- Schema Normalization and Flattening ---
 
 
@@ -679,7 +710,10 @@ def main():
     ucp_path = str((target_dir / "ucp.json").resolve())
     entity_def = {}
     if ucp_path in schemas:
-        entity_def = schemas[ucp_path].get("$defs", {}).get("entity", {})
+        entity_def = copy.deepcopy(
+            schemas[ucp_path].get("$defs", {}).get("entity", {})
+        )
+        resolve_local_refs(entity_def, schemas[ucp_path])
     if not entity_def:
         raise ValueError(
             "Entity definition not found! 'ucp.json' must define '$defs.entity'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [project]
 name = "ucp-sdk"
-version = "0.4.4"
+version = "0.4.5"
 description = "UCP Python SDK"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [
-    { name = "Enric Cusell", email = "cusell@google.com" },
     { name = "Federico D'Amato", email = "damaz@google.com" }
 ]
 classifiers = [

--- a/src/ucp_sdk/models/schemas/capability.py
+++ b/src/ucp_sdk/models/schemas/capability.py
@@ -58,56 +58,11 @@ Parent capability(s) this extends. Present for extensions, absent for root capab
 """
 
 
-Extends2 = TypeAliasType("Extends2", Extends)
-
-
-Extends3Item = TypeAliasType("Extends3Item", Extends1Item)
-
-
-Extends3 = TypeAliasType(
-    "Extends3", Annotated[list[Extends3Item], Field(..., min_length=1)]
-)
-"""
-Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
-"""
-
-
-Extends4 = TypeAliasType("Extends4", Extends)
-
-
-Extends5Item = TypeAliasType("Extends5Item", Extends1Item)
-
-
-Extends5 = TypeAliasType(
-    "Extends5", Annotated[list[Extends5Item], Field(..., min_length=1)]
-)
-"""
-Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
-"""
-
-
-Extends6 = TypeAliasType("Extends6", Extends)
-
-
-Extends7Item = TypeAliasType("Extends7Item", Extends1Item)
-
-
-Extends7 = TypeAliasType(
-    "Extends7", Annotated[list[Extends7Item], Field(..., min_length=1)]
-)
-"""
-Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
-"""
-
-
-Version = TypeAliasType("Version", Any)
-
-
 class Base(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -133,6 +88,20 @@ class Base(BaseModel):
     """
 
 
+Extends2 = TypeAliasType("Extends2", Extends)
+
+
+Extends3Item = TypeAliasType("Extends3Item", Extends1Item)
+
+
+Extends3 = TypeAliasType(
+    "Extends3", Annotated[list[Extends3Item], Field(..., min_length=1)]
+)
+"""
+Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
+"""
+
+
 class PlatformSchema(BaseModel):
     """
     Full capability declaration for platform-level discovery. Includes spec/schema URLs for agent fetching.
@@ -141,7 +110,7 @@ class PlatformSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -167,6 +136,20 @@ class PlatformSchema(BaseModel):
     """
 
 
+Extends4 = TypeAliasType("Extends4", Extends)
+
+
+Extends5Item = TypeAliasType("Extends5Item", Extends1Item)
+
+
+Extends5 = TypeAliasType(
+    "Extends5", Annotated[list[Extends5Item], Field(..., min_length=1)]
+)
+"""
+Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
+"""
+
+
 class BusinessSchema(BaseModel):
     """
     Capability configuration for business/merchant level. May include business-specific config overrides.
@@ -175,7 +158,7 @@ class BusinessSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -201,6 +184,20 @@ class BusinessSchema(BaseModel):
     """
 
 
+Extends6 = TypeAliasType("Extends6", Extends)
+
+
+Extends7Item = TypeAliasType("Extends7Item", Extends1Item)
+
+
+Extends7 = TypeAliasType(
+    "Extends7", Annotated[list[Extends7Item], Field(..., min_length=1)]
+)
+"""
+Parent capability(s) this extends. Present for extensions, absent for root capabilities. Use array for multi-parent extensions.
+"""
+
+
 class ResponseSchema(BaseModel):
     """
     Capability reference in responses. Only name/version required to confirm active capabilities.
@@ -209,7 +206,7 @@ class ResponseSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """

--- a/src/ucp_sdk/models/schemas/payment_handler.py
+++ b/src/ucp_sdk/models/schemas/payment_handler.py
@@ -33,14 +33,11 @@ Schema for UCP payment handlers. Handlers define how payment instruments are pro
 """
 
 
-Version = TypeAliasType("Version", Any)
-
-
 class Base(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -76,7 +73,7 @@ class PlatformSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -112,7 +109,7 @@ class BusinessSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -148,7 +145,7 @@ class ResponseSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """

--- a/src/ucp_sdk/models/schemas/service.py
+++ b/src/ucp_sdk/models/schemas/service.py
@@ -31,32 +31,11 @@ Service binding for a specific transport. Each transport binding is a separate e
 """
 
 
-class Config(BaseModel):
-    """
-    Entity-specific configuration. Structure defined by each entity's schema.
-    """
-
-    model_config = ConfigDict(
-        extra="allow",
-    )
-    delegate: list[str] | None = None
-    """
-    Delegations the business allows. At service-level, declares available delegations. In UCP responses, confirms accepted delegations for this session.
-    """
-    color_scheme: list[Literal["light", "dark"]] | None = None
-    """
-    Color schemes the business supports. Hosts use ec_color_scheme query parameter to request a scheme from this list.
-    """
-
-
-Version = TypeAliasType("Version", Any)
-
-
 class Base(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -94,7 +73,7 @@ class PlatformSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -132,7 +111,7 @@ class PlatformSchema7(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -170,7 +149,7 @@ class PlatformSchema8(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -208,7 +187,7 @@ class PlatformSchema9(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -258,7 +237,7 @@ class BusinessSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -296,7 +275,7 @@ class BusinessSchema4(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -334,7 +313,7 @@ class BusinessSchema5(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -364,6 +343,24 @@ class BusinessSchema5(BaseModel):
     """
 
 
+class Config(BaseModel):
+    """
+    Entity-specific configuration. Structure defined by each entity's schema.
+    """
+
+    model_config = ConfigDict(
+        extra="allow",
+    )
+    delegate: list[str] | None = None
+    """
+    Delegations the business allows. At service-level, declares available delegations. In UCP responses, confirms accepted delegations for this session.
+    """
+    color_scheme: list[Literal["light", "dark"]] | None = None
+    """
+    Color schemes the business supports. Hosts use ec_color_scheme query parameter to request a scheme from this list.
+    """
+
+
 class BusinessSchema6(BaseModel):
     """
     Service binding for business/merchant configuration. May override platform endpoints.
@@ -372,7 +369,7 @@ class BusinessSchema6(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -422,7 +419,7 @@ class ResponseSchema(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -460,7 +457,7 @@ class ResponseSchema4(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -498,7 +495,7 @@ class ResponseSchema5(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """
@@ -536,7 +533,7 @@ class ResponseSchema6(BaseModel):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: Version
+    version: str = Field(..., pattern="^\\d{4}-\\d{2}-\\d{2}$")
     """
     Entity version in YYYY-MM-DD format.
     """

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -63,6 +63,103 @@ class SchemaNormalizationTest(unittest.TestCase):
             preprocess_schemas.resolve_local_ref("other.json", schema)
         )
 
+    def test_resolve_local_refs_inlines_nested_and_transitive_pointers(
+        self,
+    ) -> None:
+        """Local references in fragment are inlined recursively with overrides."""
+        root = {
+            "$defs": {
+                "base_version": {
+                    "type": "string",
+                    "pattern": r"^\d{4}-\d{2}-\d{2}$",
+                    "description": "Default version description",
+                },
+                "version_alias": {
+                    "$ref": "#/$defs/base_version",
+                },
+            }
+        }
+        fragment = {
+            "type": "object",
+            "properties": {
+                "version": {
+                    "$ref": "#/$defs/version_alias",
+                    "description": "Entity version in YYYY-MM-DD format.",
+                }
+            },
+        }
+
+        preprocess_schemas.resolve_local_refs(fragment, root)
+
+        self.assertEqual(
+            fragment["properties"]["version"],
+            {
+                "type": "string",
+                "pattern": r"^\d{4}-\d{2}-\d{2}$",
+                "description": "Entity version in YYYY-MM-DD format.",
+            },
+        )
+
+    def test_main_inlines_entity_local_refs_without_dangling_pointers(
+        self,
+    ) -> None:
+        """Entity local refs like $defs/version are resolved before inlining into child schemas."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            preprocess_schemas.save_json(
+                {
+                    "$defs": {
+                        "version": {
+                            "type": "string",
+                            "pattern": r"^\d{4}-\d{2}-\d{2}$",
+                        },
+                        "entity": {
+                            "type": "object",
+                            "properties": {
+                                "version": {"$ref": "#/$defs/version"},
+                                "id": {"type": "string"},
+                            },
+                            "required": ["version"],
+                        },
+                    }
+                },
+                root / "ucp.json",
+            )
+            preprocess_schemas.save_json(
+                {
+                    "$id": "https://ucp.dev/schemas/capability.json",
+                    "title": "Capability",
+                    "$defs": {
+                        "base": {
+                            "allOf": [{"$ref": "ucp.json#/$defs/entity"}],
+                        }
+                    },
+                },
+                root / "capability.json",
+            )
+
+            with (
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["preprocess_schemas.py", str(root)],
+                ),
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                preprocess_schemas.main()
+
+            capability = preprocess_schemas.load_json(root / "capability.json")
+            base = capability["$defs"]["base"]
+            self.assertNotIn("allOf", base)
+            self.assertEqual(
+                base["properties"]["version"],
+                {
+                    "type": "string",
+                    "pattern": r"^\d{4}-\d{2}-\d{2}$",
+                },
+            )
+            self.assertNotIn("$ref", base["properties"]["version"])
+
     def test_preprocess_flattens_and_distributes_properties(self) -> None:
         """Flattened base fields are distributed to polymorphic branches."""
         schema = {
@@ -1845,6 +1942,37 @@ class AdditionalPropertiesForbidSemanticTest(unittest.TestCase):
 
         config = MerchantFulfillmentConfig.model_validate({"bogus": "x"})
         self.assertEqual(config.model_extra, {"bogus": "x"})
+
+
+@unittest.skipUnless(
+    HAVE_SDK, "requires the installed package (pip install -e .)"
+)
+class EntityVersionValidationSemanticTest(unittest.TestCase):
+    """Committed entity-derived models enforce version pattern validation."""
+
+    def test_capability_base_accepts_valid_version(self) -> None:
+        from ucp_sdk.models.schemas.capability import Base
+
+        model = Base.model_validate({"version": "2026-04-08", "id": "test"})
+        self.assertEqual(model.version, "2026-04-08")
+
+    def test_capability_base_rejects_invalid_version(self) -> None:
+        from ucp_sdk.models.schemas.capability import Base
+
+        with self.assertRaises(ValidationError):
+            Base.model_validate({"version": "not-a-version", "id": "test"})
+
+    def test_service_base_rejects_invalid_version(self) -> None:
+        from ucp_sdk.models.schemas.service import Base
+
+        with self.assertRaises(ValidationError):
+            Base.model_validate({"version": "invalid-format"})
+
+    def test_payment_handler_base_rejects_invalid_version(self) -> None:
+        from ucp_sdk.models.schemas.payment_handler import Base
+
+        with self.assertRaises(ValidationError):
+            Base.model_validate({"version": {"not": "a version"}})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

When preprocessing UCP schemas, `entity_def` (`ucp.json#/$defs/entity`) is extracted and inlined into schemas that compose it (`capability.json`, `service.json`, and `payment_handler.json`).

Prior to this fix, same-document references within the entity definition (specifically `"version": { "$ref": "#/$defs/version" }`) were copied verbatim into the target schemas. Because the destination schemas do not define `$defs/version`, these pointers failed to resolve against the destination document, leading to:
1. Preprocessed output with dangling local `$ref` pointers to `#/$defs/version`.
2. Eager JSON schema validators failing with `referencing.exceptions.PointerToNowhere: '/$defs/version' does not exist`.
3. `datamodel-codegen` falling back to `Version = TypeAliasType("Version", Any)`, leaving `version` unvalidated across `capability.py`, `service.py`, and `payment_handler.py`.

This change adds `resolve_local_refs` to recursively resolve and inline local `$ref` pointers in schema fragments against their origin document at extraction time. The entity definition is thus made self-contained before being inlined into consuming schemas, without introducing document-level reference cycles or modifying the external reference graph.

## Category (Required)

_Please select one or more categories that apply to this change._

- [ ] **Core Protocol**: Changes to the base communication layer, global context, or breaking refactors. (Requires Technical Council approval)
- [ ] **Governance/Contributing**: Updates to GOVERNANCE.md, CONTRIBUTING.md, or CODEOWNERS. (Requires Governance Council approval)
- [ ] **Capability**: New schemas (Discovery, Cart, etc.) or extensions. (Requires Maintainer approval)
- [ ] **Documentation**: Updates to README, or documentations regarding schema or capabilities. (Requires Maintainer approval)
- [ ] **Infrastructure**: CI/CD, Linters, or build scripts. (Requires DevOps Maintainer approval)
- [ ] **Maintenance**: Version bumps, lockfile updates, or minor bug fixes. (Requires DevOps Maintainer approval)
- [x] **SDK**: Language-specific SDK updates and releases. (Requires DevOps Maintainer approval)
- [ ] **Samples / Conformance**: Maintaining samples and the conformance suite. (Requires Maintainer approval)
- [ ] **UCP Schema**: Changes to the `ucp-schema` tool (resolver, linter, validator). (Requires Maintainer approval)
- [ ] **Community Health (.github)**: Updates to templates, workflows, or org-level configs. (Requires DevOps Maintainer approval)

## Related Issues

Fixes #72

## Checklist

- [x] I have followed the [Contributing Guide](https://github.com/Universal-Commerce-Protocol/.github/blob/main/CONTRIBUTING.md) (including Conventional Commits title requirements and `!` for breaking changes).
- [ ] I have updated the documentation (if applicable).
- [x] My changes pass all local linting and formatting checks.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] (For Core/Capability) I have included/updated the relevant JSON schemas.
- [x] I have regenerated Python Pydantic models by running generate_models.sh under python_sdk.

## Screenshots / Logs (if applicable)

N/A
